### PR TITLE
feat(assets): provide fetch and wrapper for independent assets

### DIFF
--- a/lib/embed-asset.js
+++ b/lib/embed-asset.js
@@ -1,0 +1,60 @@
+const _ = require('lodash');
+const querystring = require('querystring');
+
+/**
+ * Converts image fields into a function to construct the URL. Can either pass
+ * a width and a height separately as parameters or pass a single object with
+ * options: https://www.contentful.com/developers/docs/references/images-api
+ * @param {String} imageUrl The URL of the image field.
+ * @param {Object} config - Optional configuration to include in output. If you
+ * are using a third party image processor such as IMGIX you can include
+ * additional parameters here.
+ * @return {Function} A function which can be used in the template.
+ */
+function embedImage(imageUrl, config) {
+  // Customize the default embed parameters with the `embedParams` key passed
+  // to the constructor. If you are using a third party image processor such
+  // as IMGIX you can include additional parameters here.
+  const customParams = config.embedParams;
+
+  // Replace the `images.contentful.com` hostname with your own CDN. Your CDN
+  // should point it's root folder to your Contentful space ID for rewriting.
+  if (config.cdnHost) {
+    let hostAddress = `images.contentful.com/${config.spaceId}`;
+    imageUrl = imageUrl.replace(hostAddress, config.cdnHost);
+  }
+
+  return function(width, height) {
+    let params = typeof width === 'object' ? width :
+          _.merge({w: width, h: height}, customParams || {});
+    return `${imageUrl}?${querystring.stringify(params)}`;
+  };
+}
+
+/**
+ * Wraps a file field with a function to access the file link directly.
+ * Currently only image fields are decorated and all other files will simply
+ * return the URL of the associated file.
+ * @param {Object} file - The file field to wrap.
+ * @param {Object} config - Optional configuration to include in output.
+ * @return {String|Function} - The URL to the file or a decorator function.
+ */
+module.exports = function embedAsset(file, config) {
+  const urlOrFunc = (contentType, url, config) => {
+    switch (contentType) {
+    case 'image/jpeg':
+    case 'image/png':
+      return embedImage(url, config);
+    default:
+      return url;
+    }
+  };
+
+  if (!file.length)
+    return urlOrFunc(file.contentType, file.url, config);
+
+  return file.map((embed) => {
+    const file = embed.fields.file[config.lang || 'en-US'];
+    return urlOrFunc(file.contentType, file.url, config);
+  });
+};

--- a/lib/wrapper.js
+++ b/lib/wrapper.js
@@ -1,8 +1,9 @@
 const _ = require('lodash');
 const markdown = require('marked');
 const moment = require('moment');
-const querystring = require('querystring');
 const striptags = require('striptags');
+
+const embed = require('./embed-asset.js');
 
 /**
  * Wraps each Contentful entry with a set of convenience functions and
@@ -44,63 +45,6 @@ class ContentfulWrapper {
   }
 
   /**
-   * Wraps a file field with a function to access the file link directly.
-   * Currently only image fields are decorated and all other files will simply
-   * return the URL of the associated file. If you need access to the metadata
-   * that Contentful stores about the file you'll need to access the original
-   * object returned through `.__raw`. Support for both single and multiple
-   * value fields are included.
-   * @param {Object} file - The file field to wrap.
-   * @return {String|Function} - The URL to the file or a decorator function.
-   */
-  embed(file) {
-    const urlOrFunc = (contentType, url) => {
-      switch (contentType) {
-      case 'image/jpeg':
-      case 'image/png':
-        return this.embedImage(url);
-      default:
-        return url;
-      }
-    };
-
-    if (!file.length)
-      return urlOrFunc(file.contentType, file.url);
-
-    return file.map((embed) => {
-      const file = embed.fields.file[this.lang];
-      return urlOrFunc(file.contentType, file.url);
-    });
-  }
-
-  /**
-   * Converts image fields into a function to construct the URL. Can either pass
-   * a width and a height separately as parameters or pass a single object with
-   * options: https://www.contentful.com/developers/docs/references/images-api
-   * @param {String} imageUrl The URL of the image field.
-   * @return {Function} A function which can be used in the template.
-   */
-  embedImage(imageUrl) {
-    // Customize the default embed parameters with the `embedParams` key passed
-    // to the constructor. If you are using a third party image processor such
-    // as IMGIX you can include additional parameters here.
-    const customParams = this.config.embedParams;
-
-    // Replace the `images.contentful.com` hostname with your own CDN. Your CDN
-    // should point it's root folder to your Contentful space ID for rewriting.
-    if (this.config.cdnHost) {
-      let hostAddress = `images.contentful.com/${this.sys.space.sys.id}`;
-      imageUrl = imageUrl.replace(hostAddress, this.config.cdnHost);
-    }
-
-    return function(width, height) {
-      let params = typeof width === 'object' ? width :
-            _.merge({w: width, h: height}, customParams || {});
-      return `${imageUrl}?${querystring.stringify(params)}`;
-    };
-  }
-
-  /**
    * Return render-ready HTML markup for the field being requested. This will
    * run the field through a Markdown parser and perform file field decorations.
    * @param {String} fieldName - The name of the field to return.
@@ -137,7 +81,7 @@ class ContentfulWrapper {
     // Any file field references will decorate the value with a helper function
     // to request specific cropping or other image modifications from the CDN.
     if (_.has(field.length ? field[0] : field, `fields.file["${this.lang}"]`)) {
-      field = this.embed(field.length ? field : field.fields.file[this.lang]);
+      field = embed(field.length ? field : field.fields.file[this.lang], this.config);
     }
 
     if (_.get(field, 'sys.type') === 'Link') {


### PR DESCRIPTION
This feature will allow for assets to be pre-fetched and wrapped when specific images are needed in a static landing page. The below examples are for the treehouseaustin/web project:

On the server side:

```
ContentfulService.api.assets(['6HLBM5nSdqmoSqw2EqokSg', '1fJZclVlW8uQoS8UoiYYKs']).then(assets => {
  res.render('page', {
    staticAsset: assets
  });
});
```

And in the template:

```
<img src="staticAsset['6HLBM5nSdqmoSqw2EqokSg'](500, 500)" />
```

Will print out:

```
<img src="//treehouse.imgix.net/6HLBM5nSdqmoSqw2EqokSg/1ddab16fe308d5e4d9ac06e49efb2d2b/consultant_crop.jpg?w=&h=&auto=format%2Ccompress&crop=faces&fit=crop" />
```