### PR TITLE
fix: prevent errors if file is empty

### DIFF
--- a/transform/assets.js
+++ b/transform/assets.js
@@ -9,6 +9,8 @@ module.exports = function transformAssets(field, config) {
   const assetMeta = (fields) => {
     const lang = config.lang || 'en-US';
     const {title, description, file} = fields;
+    if (!file) return;
+
     const {details, contentType, url} = file[lang];
 
     return {
@@ -16,7 +18,7 @@ module.exports = function transformAssets(field, config) {
       description: description && description[lang] || '',
       url: ((url) => {
         if (!config.cdnHost) return url;
-        let hostAddress = `images.ctfassets.net/${config.spaceId}`;
+        const hostAddress = `images.ctfassets.net/${config.spaceId}`;
         return url.replace(hostAddress, config.cdnHost);
       })(url),
       file: {


### PR DESCRIPTION
If `file` is `null` it likely means that the file field at one point had a file, but it was removed. This gives the field the object structure to trigger the asset transformer function but `fields` is just an empty object.